### PR TITLE
Add option for a deduplicated ingest, fix compliance issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@ db.sqlite3
 .env
 
 # testing related
-.coverage
+.coverage*
 .tox
+htmlcov/
 
 # IDE stuff
 .idea/$CACHE_FILE$

--- a/chord_drs/backends/base.py
+++ b/chord_drs/backends/base.py
@@ -6,7 +6,7 @@ __all__ = ["Backend", "FakeBackend"]
 
 class Backend(ABC):
     @abstractmethod
-    def save(self, current_location: str, filename: str) -> str:
+    def save(self, current_location: str, filename: str) -> str:  # pragma: no cover
         pass
 
 

--- a/chord_drs/models.py
+++ b/chord_drs/models.py
@@ -11,6 +11,7 @@ from chord_drs.backend import get_backend
 from chord_drs.backends.minio import MinioBackend
 from chord_drs.constants import SERVICE_NAME
 from chord_drs.db import db
+from chord_drs.utils import drs_file_checksum
 
 
 class DrsMixin:
@@ -58,7 +59,7 @@ class DrsObject(db.Model, DrsMixin):
     location = db.Column(db.String(500), nullable=False)
 
     def __init__(self, *args, **kwargs):
-        location = kwargs.get('location', None)
+        location = kwargs.get("location")
         p = Path(location)
 
         if not p.exists():
@@ -83,14 +84,8 @@ class DrsObject(db.Model, DrsMixin):
         self.location = current_location
         del kwargs["location"]
 
-        hash_obj = sha256()
         self.size = os.path.getsize(location)
-
-        with open(location, "rb") as f:
-            for chunk in iter(lambda: f.read(4096), b""):
-                hash_obj.update(chunk)
-
-        self.checksum = hash_obj.hexdigest()
+        self.checksum = drs_file_checksum(location)
 
         super().__init__(*args, **kwargs)
 

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -61,16 +61,16 @@ def build_bundle_json(drs_bundle: DrsBundle, inside_container: bool = False) -> 
         content.append(obj_json)
 
     response = {
-        "contents": {
-            "contents": content,
-            "name": drs_bundle.name
-        },
-        "checksums": {
-            "checksum": drs_bundle.checksum,
-            "type": "sha-256"
-        },
+        "contents": content,
+        "checksums": [
+            {
+                "checksum": drs_bundle.checksum,
+                "type": "sha-256"
+            },
+        ],
         "created_time": f"{drs_bundle.created.isoformat('T')}Z",
         "size": drs_bundle.size,
+        "name": drs_bundle.name,
         "description": drs_bundle.description,
         "id": drs_bundle.id,
         "self_uri": create_drs_uri(drs_bundle.id)
@@ -115,10 +115,12 @@ def build_object_json(drs_object: DrsObject, inside_container: bool = False) -> 
 
     response = {
         "access_methods": access_methods,
-        "checksums": {
-            "checksum": drs_object.checksum,
-            "type": "sha-256"
-        },
+        "checksums": [
+            {
+                "checksum": drs_object.checksum,
+                "type": "sha-256"
+            },
+        ],
         "created_time": f"{drs_object.created.isoformat('T')}Z",
         "size": drs_object.size,
         "name": drs_object.name,

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -1,5 +1,4 @@
 import re
-from urllib.parse import urljoin, urlparse
 
 from chord_lib.responses import flask_errors
 from flask import (
@@ -12,12 +11,15 @@ from flask import (
     make_response
 )
 from sqlalchemy.orm.exc import NoResultFound
+from typing import Optional
+from urllib.parse import urljoin, urlparse
 
 from chord_drs import __version__
 from chord_drs.constants import SERVICE_NAME, SERVICE_TYPE
 from chord_drs.data_sources import DATA_SOURCE_LOCAL, DATA_SOURCE_MINIO
 from chord_drs.db import db
 from chord_drs.models import DrsObject, DrsBundle
+from chord_drs.utils import drs_file_checksum
 
 
 RE_STARTING_SLASH = re.compile(r"^/")
@@ -135,7 +137,7 @@ def service_info():
         "id": current_app.config["SERVICE_ID"],
         "name": SERVICE_NAME,
         "type": SERVICE_TYPE,
-        "description": "Data repository service (based on GA4GH's specs) for a CHORD application.",
+        "description": "Data repository service (based on GA4GH's specs) for a Bento platform node.",
         "organization": {
             "name": "C3G",
             "url": "http://c3g.ca"
@@ -219,21 +221,32 @@ def object_download(object_id):
 
 @drs_service.route("/private/ingest", methods=["POST"])
 def object_ingest():
-    try:
-        data = request.json
-        obj_path = data["path"]
-    except KeyError:
-        return flask_errors.flask_bad_request_error("Missing path parameter in JSON request")
+    data = request.json or {}
 
-    try:
-        new_object = DrsObject(location=obj_path)
+    obj_path: str = data.get("path")
 
-        db.session.add(new_object)
-        db.session.commit()
-    except Exception as e:  # TODO: More specific handling
-        current_app.logger.error(f"[{SERVICE_NAME}] Encountered exception during ingest: {e}")
-        return flask_errors.flask_bad_request_error("Error while creating the object")
+    if not obj_path or not isinstance(obj_path, str):
+        return flask_errors.flask_bad_request_error("Missing or invalid path parameter in JSON request")
 
-    response = build_object_json(new_object)
+    # TODO: Should this always be the case?
+    deduplicate: bool = data.get("deduplicate", False)
+
+    drs_object: Optional[DrsObject] = None
+    if deduplicate:
+        # Get checksum of original file, and query database for objects that match
+        checksum = drs_file_checksum(obj_path)
+        drs_object = DrsObject.query.filter_by(checksum=checksum).first()
+
+    if not drs_object:
+        try:
+            drs_object = DrsObject(location=obj_path)
+
+            db.session.add(drs_object)
+            db.session.commit()
+        except Exception as e:  # TODO: More specific handling
+            current_app.logger.error(f"[{SERVICE_NAME}] Encountered exception during ingest: {e}")
+            return flask_errors.flask_bad_request_error("Error while creating the object")
+
+    response = build_object_json(drs_object)
 
     return response, 201

--- a/chord_drs/utils.py
+++ b/chord_drs/utils.py
@@ -1,0 +1,14 @@
+from hashlib import sha256
+
+
+__all__ = ["drs_file_checksum"]
+
+
+def drs_file_checksum(path: str) -> str:
+    hash_obj = sha256()
+
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_obj.update(chunk)
+
+    return hash_obj.hexdigest()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,9 +1,9 @@
-from jsonschema import validate
 import chord_lib
+from jsonschema import validate
 from tests.conftest import NON_EXISTENT_DUMMY_FILE, DUMMY_FILE
 
 
-NON_EXISTENT_ID = '123'
+NON_EXISTENT_ID = "123"
 
 
 def validate_object_fields(data, existing_id=None):
@@ -29,47 +29,41 @@ def test_service_info(client):
 
 
 def test_object_fail(client):
-    res = client.get(f'/objects/{NON_EXISTENT_ID}')
+    res = client.get(f"/objects/{NON_EXISTENT_ID}")
 
     assert res.status_code == 404
 
 
 def test_object_download_fail(client):
-    res = client.get(f'/objects/{NON_EXISTENT_ID}/download')
+    res = client.get(f"/objects/{NON_EXISTENT_ID}/download")
 
     assert res.status_code == 404
 
 
-def test_object_and_download_minio(client_minio, drs_object_minio):
-    res = client_minio.get(f'/objects/{drs_object_minio.id}')
+def _test_object_and_download(client, obj):
+    res = client.get(f"/objects/{obj.id}")
     data = res.get_json()
 
     assert res.status_code == 200
-    validate_object_fields(data, existing_id=drs_object_minio.id)
-
-    # Download the object
-    res = client_minio.get(data["access_methods"][0]["access_url"]["url"])
-
-    assert res.status_code == 200
-    assert res.content_length == drs_object_minio.size
-
-
-def test_object_and_download(client, drs_object):
-    res = client.get(f'/objects/{drs_object.id}')
-    data = res.get_json()
-
-    assert res.status_code == 200
-    validate_object_fields(data, existing_id=drs_object.id)
+    validate_object_fields(data, existing_id=obj.id)
 
     # Download the object
     res = client.get(data["access_methods"][0]["access_url"]["url"])
 
     assert res.status_code == 200
-    assert res.content_length == drs_object.size
+    assert res.content_length == obj.size
+
+
+def test_object_and_download_minio(client_minio, drs_object_minio):
+    _test_object_and_download(client_minio, drs_object_minio)
+
+
+def test_object_and_download(client, drs_object):
+    _test_object_and_download(client, drs_object)
 
 
 def test_object_inside_bento(client, drs_object):
-    res = client.get(f'/objects/{drs_object.id}', headers={'X-CHORD-Internal': '1'})
+    res = client.get(f"/objects/{drs_object.id}", headers={'X-CHORD-Internal': '1'})
     data = res.get_json()
 
     assert res.status_code == 200
@@ -103,41 +97,54 @@ def test_bundle_and_download(client, drs_bundle):
 
 
 def test_search_object_empty(client, drs_bundle):
-    res = client.get('/search')
-    data = res.get_json()
+    res = client.get("/search")
 
     assert res.status_code == 400
 
-    res = client.get('/search?name=asd')
-    data = res.get_json()
+    for url in ("/search?name=asd", "/search?fuzzy_name=asd"):
+        res = client.get(url)
+        data = res.get_json()
 
-    assert res.status_code == 200
-    assert len(data) == 0
+        assert res.status_code == 200
+        assert len(data) == 0
 
 
 def test_search_object(client, drs_bundle):
-    res = client.get('/search?name=alembic.ini')
-    data = res.get_json()
+    for url in ("/search?name=alembic.ini", "/search?fuzzy_name=mbic"):
+        res = client.get(url)
+        data = res.get_json()
 
-    assert res.status_code == 200
-    assert len(data) == 1
+        assert res.status_code == 200
+        assert len(data) == 1
 
-    validate_object_fields(data[0])
+        validate_object_fields(data[0])
 
 
 def test_object_ingest_fail(client):
-    res = client.post('/private/ingest', json={'wrong_arg': 'some_path'})
+    res = client.post("/private/ingest", json={"wrong_arg": "some_path"})
 
     assert res.status_code == 400
 
-    res = client.post('/private/ingest', json={'path': NON_EXISTENT_DUMMY_FILE})
+    res = client.post("/private/ingest", json={"path": NON_EXISTENT_DUMMY_FILE})
 
     assert res.status_code == 400
 
 
-def test_object_ingest(client):
-    res = client.post('/private/ingest', json={'path': DUMMY_FILE})
+def _ingest_one(client, existing_id=None, params=None):
+    res = client.post("/private/ingest", json={"path": DUMMY_FILE, **(params or {})})
     data = res.get_json()
 
     assert res.status_code == 201
-    validate_object_fields(data)
+    validate_object_fields(data, existing_id=existing_id)
+
+    return data
+
+
+def test_object_ingest(client):
+    _ingest_one(client)
+
+
+def test_object_ingest_deduplicate(client):
+    data = _ingest_one(client)
+    data_2 = _ingest_one(client, data["id"], {"deduplicate": True})
+    assert data["checksums"][0]["checksum"] == data_2["checksums"][0]["checksum"]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,4 +1,6 @@
 import chord_lib
+import json
+
 from jsonschema import validate
 from tests.conftest import NON_EXISTENT_DUMMY_FILE, DUMMY_FILE
 
@@ -144,7 +146,13 @@ def test_object_ingest(client):
     _ingest_one(client)
 
 
+def test_object_ingest_x2(client):
+    data_1 = _ingest_one(client)
+    data_2 = _ingest_one(client)
+    assert data_1["id"] != data_2["id"]
+
+
 def test_object_ingest_deduplicate(client):
-    data = _ingest_one(client)
-    data_2 = _ingest_one(client, data["id"], {"deduplicate": True})
-    assert data["checksums"][0]["checksum"] == data_2["checksums"][0]["checksum"]
+    data_1 = _ingest_one(client)
+    data_2 = _ingest_one(client, data_1["id"], {"deduplicate": True})
+    assert json.dumps(data_1, sort_keys=True) == json.dumps(data_2, sort_keys=True)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -12,8 +12,7 @@ def validate_object_fields(data, existing_id=None):
     assert len(data["access_methods"]) == 2
     assert "access_url" in data["access_methods"][0]
     assert "url" in data["access_methods"][0]["access_url"]
-
-    assert "checksums" in data
+    assert "checksums" in data and len("checksums") > 0
     assert "created_time" in data
     assert "size" in data
     assert "self_uri" in data
@@ -78,24 +77,24 @@ def test_object_inside_bento(client, drs_object):
 
 
 def test_bundle_and_download(client, drs_bundle):
-    res = client.get(f'/objects/{drs_bundle.id}')
+    res = client.get(f"/objects/{drs_bundle.id}")
     data = res.get_json()
 
     assert res.status_code == 200
     assert "access_methods" not in data
-    assert "contents" in data
-    assert "name" in data["contents"] and data["contents"]["name"] == drs_bundle.name
     # issue again with the number of files ingested when ran locally vs travis-ci
-    assert "contents" in data["contents"] and len(data["contents"]["contents"]) > 0
+    assert "contents" in data and len(data["contents"]) > 0
+    assert "name" in data and data["name"] == drs_bundle.name
 
-    assert "checksums" in data
+    assert "checksums" in data and len("checksums") > 0
+
     assert "created_time" in data
     assert "size" in data
     assert "id" in data and data["id"] == drs_bundle.id
 
     # jsonify sort alphabetically - makes it that the last element will be
     # an object and not a bundle
-    obj = data["contents"]["contents"][-1]
+    obj = data["contents"][-1]
 
     res = client.get(obj["access_methods"][0]["access_url"]["url"])
 


### PR DESCRIPTION
* There were some issues with the responses for objects/bundles that have been fixed
* Added a `deduplicate` option for ingest
   * Uses existing objects with a matching checksum if available