### PR TITLE
send_file mimetype patch

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+exclude = .git,.tox,__pycache__

--- a/chord_drs/package.cfg
+++ b/chord_drs/package.cfg
@@ -1,5 +1,5 @@
 [package]
 name = chord_drs
-version = 0.3.0
+version = 0.4.0
 authors = Simon Chénard, David Lougheed
 author_emails = simon.chenard2@mcgill.ca, david.lougheed@mail.mcgill.ca

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -214,7 +214,7 @@ def object_download(object_id):
         with open(drs_object.location, 'rb') as fh:
             # Check for "Range" HTTP header
             bytesTag = request.headers.get('Range')  # supports "headers={'Range': 'bytes=x-y'}"
-            if bytesTag != "":
+            if bytesTag != None:
                 current_app.logger.debug(f"Found Range header: {bytesTag}")
                 
                 bytesSplit = bytesTag.split("=")

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -212,7 +212,22 @@ def object_download(object_id):
 
     if not minio_obj:
         with open(drs_object.location, 'rb') as fh:
-            buf = BytesIO(fh.read()) # supports "headers={'Range': 'bytes=x-y'}"
+            # Check for "Range" HTTP header
+            bytesTag = request.headers.get('Range')  # supports "headers={'Range': 'bytes=x-y'}"
+            if bytesTag != "":
+                print(f"Found Range header: {bytesTag}")
+                bytesSplit = bytesTag.split("=")
+                print(f"Found bytesSplit {bytesSplit}")
+                rangeSplit = bytesSplit[1].strip().split("-")
+                print(f"Found rangeSplit {rangeSplit}")
+
+                fh.seek(rangeSplit[0])
+                data = fh.read(rangeSplit[1] - rangeSplit[0])
+
+                buf = BytesIO(data)
+            else:
+                buf = BytesIO(fh.read())
+
             return send_file(buf, mimetype="application/octet-stream")
 
     # TODO: kinda greasy, not really sure we want to support such a feature later on

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -1,6 +1,5 @@
 import re
-
-from io import BytesIO
+import urllib.parse
 
 from bento_lib.responses import flask_errors
 from flask import (
@@ -25,6 +24,8 @@ from chord_drs.utils import drs_file_checksum
 
 
 RE_STARTING_SLASH = re.compile(r"^/")
+MIME_OCTET_STREAM = "application/octet-stream"
+CHUNK_SIZE = 1024 * 16  # Read 16 KB at a time
 
 drs_service = Blueprint("drs_service", __name__)
 
@@ -211,30 +212,64 @@ def object_download(object_id):
     minio_obj = drs_object.return_minio_object()
 
     if not minio_obj:
-        with open(drs_object.location, 'rb') as fh:
-            # Check for "Range" HTTP header
-            bytesTag = request.headers.get('Range')  # supports "headers={'Range': 'bytes=x-y'}"
-            if bytesTag is not None:
-                current_app.logger.debug(f"Found Range header: {bytesTag}")
+        # Check for "Range" HTTP header
+        range_header = request.headers.get("Range")  # supports "headers={'Range': 'bytes=x-y'}"
 
-                bytesSplit = bytesTag.split("=")
-                current_app.logger.debug(f"Found bytesSplit {bytesSplit}")
+        if range_header is None:
+            # Early return, no range header so send the whole thing
+            return send_file(
+                drs_object.location,
+                mimetype=MIME_OCTET_STREAM,
+                attachment_filename=drs_object.name,
+            )
 
-                rangeSplit = bytesSplit[1].strip().split("-")
-                current_app.logger.debug(f"Found rangeSplit {rangeSplit}")
+        current_app.logger.debug(f"Found Range header: {range_header}")
 
-                start = int(rangeSplit[0])
-                end = int(rangeSplit[1])
+        rh_split = range_header.split("=")
+        if len(rh_split) != 2 or rh_split[0] != "bytes":
+            err = f"Malformatted range header: expected bytes=X-Y or bytes=X-, got {range_header}"
+            current_app.logger.error(err)
+            return flask_errors.flask_bad_request_error(err)
 
-                fh.seek(start)
-                data = fh.read(end - start)
+        byte_range = rh_split[1].strip().split("-")
+        current_app.logger.debug(f"Retrieving byte range {byte_range}")
 
-                buf = BytesIO(data)
-            else:
-                buf = BytesIO(fh.read())
+        start = int(byte_range[0])
+        end = int(byte_range[1]) if byte_range[1] else None
 
-            return send_file(buf, mimetype="application/octet-stream")
+        if end is not None and end < start:
+            err = f"Invalid range header: end cannot be less than start (start={start}, end={end})"
+            current_app.logger.error(err)
+            return flask_errors.flask_bad_request_error(err)
 
+        def generate_bytes():
+            with open(drs_object.location, "rb") as fh2:
+                # First, skip over <start> bytes to get to the beginning of the range
+                fh2.seek(start)
+
+                # Then, read in either CHUNK_SIZE byte segments or however many bytes are left to send, whichever is
+                # left. This avoids filling memory with the contents of large files.
+                byte_offset = start
+                while True:
+                    # Add a 1 to the amount to read if it's below chunk size, because the last coordinate is inclusive.
+                    data = fh2.read(min(CHUNK_SIZE, (end + 1 - byte_offset) if end is not None else CHUNK_SIZE))
+                    byte_offset += len(data)
+                    yield data
+
+                    # If we've hit the end of the file and are reading empty byte strings, or we've reached the
+                    # end of our range (inclusive), then escape the loop.
+                    # This is guaranteed to terminate with a finite-sized file.
+                    if len(data) == 0 or (end is not None and byte_offset > end):
+                        break
+
+        # Stream the bytes of the file or file segment from the generator function
+        r = current_app.response_class(generate_bytes(), status=206, mimetype=MIME_OCTET_STREAM)
+        r.headers["Accept-Ranges"] = "bytes"
+        r.headers["Content-Disposition"] = \
+            f"attachment; filename*=UTF-8'{urllib.parse.quote(drs_object.name, encoding='utf-8')}'"
+        return r
+
+    # TODO: Support range headers for MinIO objects - only the local backend supports it for now
     # TODO: kinda greasy, not really sure we want to support such a feature later on
     response = make_response(
         send_file(

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -214,7 +214,7 @@ def object_download(object_id):
         with open(drs_object.location, 'rb') as fh:
             # Check for "Range" HTTP header
             bytesTag = request.headers.get('Range')  # supports "headers={'Range': 'bytes=x-y'}"
-            if bytesTag != None:
+            if bytesTag is not None:
                 current_app.logger.debug(f"Found Range header: {bytesTag}")
                 
                 bytesSplit = bytesTag.split("=")

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -209,8 +209,7 @@ def object_download(object_id):
     minio_obj = drs_object.return_minio_object()
 
     if not minio_obj:
-        return send_file(drs_object.location,
-            mimetype="application/octet-stream")
+        return send_file(drs_object.location, mimetype="application/octet-stream")
 
     # TODO: kinda greasy, not really sure we want to support such a feature later on
     response = make_response(

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -1,5 +1,7 @@
 import re
 
+from io import BytesIO
+
 from bento_lib.responses import flask_errors
 from flask import (
     Blueprint,
@@ -209,7 +211,9 @@ def object_download(object_id):
     minio_obj = drs_object.return_minio_object()
 
     if not minio_obj:
-        return send_file(drs_object.location, mimetype="application/octet-stream")
+        with open(drs_object.location, 'rb') as fh:
+            buf = BytesIO(fh.read()) # supports "headers={'Range': 'bytes=x-y'}"
+            return send_file(buf, mimetype="application/octet-stream")
 
     # TODO: kinda greasy, not really sure we want to support such a feature later on
     response = make_response(

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -209,7 +209,8 @@ def object_download(object_id):
     minio_obj = drs_object.return_minio_object()
 
     if not minio_obj:
-        return send_file(drs_object.location)
+        return send_file(drs_object.location,
+            mimetype="application/octet-stream")
 
     # TODO: kinda greasy, not really sure we want to support such a feature later on
     response = make_response(

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -216,15 +216,15 @@ def object_download(object_id):
             bytesTag = request.headers.get('Range')  # supports "headers={'Range': 'bytes=x-y'}"
             if bytesTag is not None:
                 current_app.logger.debug(f"Found Range header: {bytesTag}")
-                
+
                 bytesSplit = bytesTag.split("=")
                 current_app.logger.debug(f"Found bytesSplit {bytesSplit}")
-                
+
                 rangeSplit = bytesSplit[1].strip().split("-")
                 current_app.logger.debug(f"Found rangeSplit {rangeSplit}")
 
-                start=int(rangeSplit[0])
-                end=int(rangeSplit[1])
+                start = int(rangeSplit[0])
+                end = int(rangeSplit[1])
 
                 fh.seek(start)
                 data = fh.read(end - start)

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -215,14 +215,19 @@ def object_download(object_id):
             # Check for "Range" HTTP header
             bytesTag = request.headers.get('Range')  # supports "headers={'Range': 'bytes=x-y'}"
             if bytesTag != "":
-                print(f"Found Range header: {bytesTag}")
+                current_app.logger.debug(f"Found Range header: {bytesTag}")
+                
                 bytesSplit = bytesTag.split("=")
-                print(f"Found bytesSplit {bytesSplit}")
+                current_app.logger.debug(f"Found bytesSplit {bytesSplit}")
+                
                 rangeSplit = bytesSplit[1].strip().split("-")
-                print(f"Found rangeSplit {rangeSplit}")
+                current_app.logger.debug(f"Found rangeSplit {rangeSplit}")
 
-                fh.seek(rangeSplit[0])
-                data = fh.read(rangeSplit[1] - rangeSplit[0])
+                start=int(rangeSplit[0])
+                end=int(rangeSplit[1])
+
+                fh.seek(start)
+                data = fh.read(end - start)
 
                 buf = BytesIO(data)
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ cryptography==3.4.7
 distlib==0.3.2
 filelock==3.0.12
 flake8==3.9.2
+flake8-polyfill==1.0.2
 Flask==1.1.4
 Flask-Migrate==3.0.1
 Flask-SQLAlchemy==2.5.1
@@ -31,6 +32,7 @@ mock==4.0.3
 more-itertools==8.8.0
 moto==2.0.9
 packaging==20.9
+pep8-naming==0.12.1
 pluggy==0.13.1
 prometheus-client==0.9.0
 prometheus-flask-exporter==0.14.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from chord_drs.models import DrsObject
 
 SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
 NON_EXISTENT_DUMMY_FILE = os.path.join(BASEDIR, "potato")
-DUMMY_FILE = os.path.join(BASEDIR, "README.md")
+DUMMY_FILE = os.path.join(BASEDIR, "tests", "dummy_file.txt")
 DUMMY_DIRECTORY = os.path.join(APP_DIR, "migrations")
 
 

--- a/tests/dummy_file.txt
+++ b/tests/dummy_file.txt
@@ -1,0 +1,79 @@
+# CHORD Data Repository Service
+
+![Test Status](https://github.com/c3g/chord_drs/workflows/Test/badge.svg)
+![Lint Status](https://github.com/c3g/chord_drs/workflows/Lint/badge.svg)
+[![codecov](https://codecov.io/gh/c3g/chord_drs/branch/master/graph/badge.svg)](https://codecov.io/gh/c3g/chord_drs)
+
+A proof of concept based on [GA4GH's DRS specifications](https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.0.0/docs/).
+This flask application offers an interface to query files in such
+a fashion: "drs://some-domain/some-ID".
+
+For storing the files, two methods are currently supported : in the current filesystem
+or inside a MinIO instance (which is a s3-like software).
+
+## TODO / Future considerations
+
+ - Ingesting is either through the command line or by the endpoint of the same name
+ (which will create a single object). There is currently no way to ingest an archive
+ or to package objects into bundles.
+ - Consider how to be aware of http vs https depending on the deployment setup
+ (in singularity, docker, as is).
+
+## Configuration
+
+At the root of this project there is a sample dotenv file (.env-sample). These can be
+exported as environment variables or used as is. Simply copy the sample file and
+provide the missing values.
+
+```bash
+cp .env-sample .env
+```
+
+## Running in Development
+
+Development dependencies are described in `requirements.txt` and can be
+installed using the following command:
+
+```bash
+pip install -r requirements.txt
+```
+
+Afterwards we need to setup the DB:
+
+```bash
+flask db upgrade
+```
+
+Most likely you will want to load some objects to serve through this service.
+This can be done with this command (ingestion is recursive for directories):
+
+```bash
+flask ingest $A_FILE_OR_A_DIRECTORY
+```
+
+The Flask development server can be run with the following command:
+
+```bash
+FLASK_DEBUG=True flask run
+```
+
+## Running Tests
+
+To run all tests and calculate coverage, run the following command:
+
+```bash
+tox
+```
+
+Tox is configured to run both pytest and flake8, you may want to uncomment
+the second line of tox.ini (envlist = ...) so as to run these commands
+for multiple versions of Python.
+
+## Deploying
+
+In production, the service should be deployed using a WSGI service like
+[uWSGI](https://uwsgi-docs.readthedocs.io/en/latest/).
+
+With uWSGI you should point to chord_drs.app:application, the wsgi.py file
+at the root of the project is there to simplify executing the commands (such
+as "ingest")

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,6 @@
 [tox]
 # envlist = py36, py38
 
-[flake8]
-max-line-length = 120
-exclude = .git,.tox,__pycache__
-
 [testenv]
 skip_install = true
 setenv =


### PR DESCRIPTION
- force octet-stream MIME type so Flask doesn't guess the Content-Type upon file retrieval
- support 'Range: bytes=x-y' HTTP header on `.../download` endpoint